### PR TITLE
Add Integration Test cases for Home Controller and Implement GlobalExceptionHandler with Custom CategoryNotFoundException 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/javaProject/AptitudeApp/controller/AdminController.java
+++ b/src/main/java/com/javaProject/AptitudeApp/controller/AdminController.java
@@ -33,19 +33,19 @@ public class AdminController {
         return new ResponseEntity<>(topicDtoList, HttpStatus.OK);
     }
 
-    @PostMapping("/topic/add")
+    @PostMapping("/topic")
     public ResponseEntity<String> addTopic(@RequestBody TopicCreationDto topicCreationDto) {
         String responseText =  adminService.addTopic(topicCreationDto.getTopicName(), topicCreationDto.getCategoryId(), topicCreationDto.getSlug());
         return new ResponseEntity<>(responseText, HttpStatus.CREATED);
     }
 
-    @PostMapping("/learning-resource/add")
+    @PostMapping("/learning-resource")
     public ResponseEntity<String> addLearningResource(@RequestBody LearningResourceCreationDto learningResourceCreationDto) {
         String responseText = adminService.addLearningResource(learningResourceCreationDto.getResourceUrl(), learningResourceCreationDto.getTopicId());
         return new ResponseEntity<>(responseText, HttpStatus.CREATED);
     }
 
-    @PostMapping("/question/add")
+    @PostMapping("/question")
     public ResponseEntity<String> addQuestion(@RequestBody QuestionCreationDto questionCreationDto) {
         String responseText = adminService.addQuestion(
                 questionCreationDto.getQuestion(),

--- a/src/main/java/com/javaProject/AptitudeApp/controller/HomeController.java
+++ b/src/main/java/com/javaProject/AptitudeApp/controller/HomeController.java
@@ -31,7 +31,7 @@ public class HomeController {
         return new ResponseEntity<>(categoryDto, HttpStatus.OK);
     }
 
-    @GetMapping("/topics/{categoryId}")
+    @GetMapping("/categories/{categoryId}/topics")
     public ResponseEntity<List<TopicDto>> getTopicsByCategory(@PathVariable Long categoryId) {
         List<TopicDto> topicDto = homeService.getTopicsByCategory(categoryId);
         return new ResponseEntity<>(topicDto, HttpStatus.OK);

--- a/src/main/java/com/javaProject/AptitudeApp/controller/QuizController.java
+++ b/src/main/java/com/javaProject/AptitudeApp/controller/QuizController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/{slug}/quiz")
+@RequestMapping("/topics/{slug}")
 public class QuizController {
 
     private ISetupQuiz setupQuiz;
@@ -24,7 +24,7 @@ public class QuizController {
         this.setupQuiz = setupQuiz;
     }
 
-    @GetMapping("/")
+    @GetMapping("/quiz")
     public ResponseEntity<List<QuestionDto>> getRandomQuestions(@PathVariable String slug) {
         List<QuestionDto> questionList = setupQuiz.getQuestionForSlug(slug);
         return new ResponseEntity<>(questionList, HttpStatus.OK);

--- a/src/main/java/com/javaProject/AptitudeApp/controller/TopicController.java
+++ b/src/main/java/com/javaProject/AptitudeApp/controller/TopicController.java
@@ -24,7 +24,7 @@ public class TopicController {
         this.topicService = topicService;
     }
 
-    @GetMapping("/resource")
+    @GetMapping("/resources")
     public ResponseEntity<List<LearningResourceDto>> getLearningResources(@PathVariable String slug) {
         List<LearningResourceDto> learningResources = topicService.getLearningResourcesByTopic(slug);
         return new ResponseEntity<>(learningResources, HttpStatus.OK);

--- a/src/main/java/com/javaProject/AptitudeApp/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/javaProject/AptitudeApp/exception/CategoryNotFoundException.java
@@ -1,0 +1,7 @@
+package com.javaProject.AptitudeApp.exception;
+
+public class CategoryNotFoundException extends RuntimeException {
+    public CategoryNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/javaProject/AptitudeApp/exception/ErrorResponse.java
+++ b/src/main/java/com/javaProject/AptitudeApp/exception/ErrorResponse.java
@@ -4,12 +4,6 @@ public class ErrorResponse {
     private int statusCode;
     private String message;
 
-    public ErrorResponse(String message)
-    {
-        super();
-        this.message = message;
-    }
-
     public ErrorResponse(int statusCode, String message) {
         this.statusCode = statusCode;
         this.message = message;

--- a/src/main/java/com/javaProject/AptitudeApp/exception/ErrorResponse.java
+++ b/src/main/java/com/javaProject/AptitudeApp/exception/ErrorResponse.java
@@ -1,8 +1,8 @@
 package com.javaProject.AptitudeApp.exception;
 
 public class ErrorResponse {
-    private int statusCode;
-    private String message;
+    private final int statusCode;
+    private final String message;
 
     public ErrorResponse(int statusCode, String message) {
         this.statusCode = statusCode;
@@ -13,15 +13,7 @@ public class ErrorResponse {
         return statusCode;
     }
 
-    public void setStatusCode(int statusCode) {
-        this.statusCode = statusCode;
-    }
-
     public String getMessage() {
         return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
     }
 }

--- a/src/main/java/com/javaProject/AptitudeApp/exception/ErrorResponse.java
+++ b/src/main/java/com/javaProject/AptitudeApp/exception/ErrorResponse.java
@@ -1,0 +1,33 @@
+package com.javaProject.AptitudeApp.exception;
+
+public class ErrorResponse {
+    private int statusCode;
+    private String message;
+
+    public ErrorResponse(String message)
+    {
+        super();
+        this.message = message;
+    }
+
+    public ErrorResponse(int statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/javaProject/AptitudeApp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/javaProject/AptitudeApp/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.javaProject.AptitudeApp.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = CategoryNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleException(CategoryNotFoundException ex) {
+        return new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+    }
+}

--- a/src/main/java/com/javaProject/AptitudeApp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/javaProject/AptitudeApp/exception/GlobalExceptionHandler.java
@@ -10,7 +10,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = CategoryNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public ErrorResponse handleException(CategoryNotFoundException ex) {
+    public ErrorResponse handleCategoryNotFoundException(CategoryNotFoundException ex) {
         return new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
     }
 }

--- a/src/main/java/com/javaProject/AptitudeApp/service/Impl/HomeService.java
+++ b/src/main/java/com/javaProject/AptitudeApp/service/Impl/HomeService.java
@@ -4,6 +4,7 @@ import com.javaProject.AptitudeApp.dao.ICategoryRepo;
 import com.javaProject.AptitudeApp.dao.ITopicRepo;
 import com.javaProject.AptitudeApp.dto.CategoryDto;
 import com.javaProject.AptitudeApp.dto.TopicDto;
+import com.javaProject.AptitudeApp.exception.CategoryNotFoundException;
 import com.javaProject.AptitudeApp.model.Category;
 import com.javaProject.AptitudeApp.model.Topic;
 import com.javaProject.AptitudeApp.service.IHomeService;
@@ -37,7 +38,7 @@ public class HomeService implements IHomeService {
     @Override
     public List<TopicDto> getTopicsByCategory(Long categoryId) {
         Category category = categoryRepo.findById(categoryId).orElseThrow(
-                () -> new RuntimeException("Category not found with id: " + categoryId));
+                () -> new CategoryNotFoundException("Category not found with id: " + categoryId));
         List<Topic> allTopics = topicRepo.findByCategory(category);
         return allTopics.stream().map(topic -> new TopicDto(topic.getTopicId(), topic.getTopicName(), topic.getSlug())).toList();
     }

--- a/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
+++ b/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
@@ -3,22 +3,24 @@ package com.javaProject.AptitudeApp.controller;
 import com.javaProject.AptitudeApp.dto.CategoryDto;
 import com.javaProject.AptitudeApp.dto.TopicDto;
 import com.javaProject.AptitudeApp.exception.CategoryNotFoundException;
+import com.javaProject.AptitudeApp.exception.GlobalExceptionHandler;
 import com.javaProject.AptitudeApp.service.Impl.HomeService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(HomeController.class)
+@Import(GlobalExceptionHandler.class)
 public class HomeControllerTests {
 
     @Autowired

--- a/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
+++ b/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
@@ -59,7 +59,7 @@ public class HomeControllerTests {
 
     @Test
     public void testGetTopicsByCategoryId() throws Exception {
-        Long categoryId = 1L;
+        long categoryId = 1L;
         Mockito.when(homeService.getTopicsByCategory(categoryId))
                 .thenReturn(
                         List.of(
@@ -79,7 +79,7 @@ public class HomeControllerTests {
 
     @Test
     public void testGetTopicsByCategoryId_EmptyList() throws Exception {
-        Long categoryId = 1L;
+        long categoryId = 1L;
         Mockito.when(homeService.getTopicsByCategory(categoryId))
                 .thenReturn(List.of());
 
@@ -91,7 +91,7 @@ public class HomeControllerTests {
 
     @Test
     public void testGetTopicsByCategoryId_InvalidId() throws Exception {
-        Long categoryId = 999L;
+        long categoryId = 999L;
         Mockito.when(homeService.getTopicsByCategory(categoryId))
                 .thenThrow(new CategoryNotFoundException("Category not found with id: " + categoryId));
 

--- a/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
+++ b/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
@@ -2,6 +2,7 @@ package com.javaProject.AptitudeApp.controller;
 
 import com.javaProject.AptitudeApp.dto.CategoryDto;
 import com.javaProject.AptitudeApp.dto.TopicDto;
+import com.javaProject.AptitudeApp.exception.CategoryNotFoundException;
 import com.javaProject.AptitudeApp.service.Impl.HomeService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -90,7 +91,7 @@ public class HomeControllerTests {
     public void testGetTopicsByCategoryId_InvalidId() throws Exception {
         Long categoryId = 999L;
         Mockito.when(homeService.getTopicsByCategory(categoryId))
-                .thenReturn(List.of());
+                .thenThrow(new CategoryNotFoundException("Category not found with id: " + categoryId));
 
         mockMvc.perform(get("/categories/{categoryId}/topics", categoryId))
                 .andExpect(status().isInternalServerError())

--- a/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
+++ b/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
@@ -1,0 +1,116 @@
+package com.javaProject.AptitudeApp.controller;
+
+import com.javaProject.AptitudeApp.dto.CategoryDto;
+import com.javaProject.AptitudeApp.dto.TopicDto;
+import com.javaProject.AptitudeApp.service.Impl.HomeService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(HomeController.class)
+public class HomeControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private HomeService homeService;
+
+    @Test
+    public void testGetAllCategories() throws Exception {
+        Mockito.when(homeService.getAllCategories())
+                .thenReturn(
+                        List.of(
+                                new CategoryDto(1L, "Quantitative Aptitude"),
+                                new CategoryDto(2L, "Logical Aptitude"))
+                );
+
+        mockMvc.perform(get("/categories"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].categoryName").value("Quantitative Aptitude"))
+                .andExpect(jsonPath("$[1].categoryName").value("Logical Aptitude"));
+    }
+
+    @Test
+    public void testGetAllCategories_EmptyList() throws Exception {
+        Mockito.when(homeService.getAllCategories())
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/categories"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    public void testGetTopicsByCategoryId() throws Exception {
+        Long categoryId = 1L;
+        Mockito.when(homeService.getTopicsByCategory(categoryId))
+                .thenReturn(
+                        List.of(
+                                new TopicDto(1L, "Time and Work","time-and-work"),
+                                new TopicDto(2L, "Time and Distance","time-and-distance"),
+                                new TopicDto(3L, "Boats and Streams","boats-and-streams"))
+                );
+
+        mockMvc.perform(get("/categories/{categoryId}/topics", categoryId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].topicName").value("Time and Work"))
+                .andExpect(jsonPath("$[1].topicName").value("Time and Distance"))
+                .andExpect(jsonPath("$[2].topicName").value("Boats and Streams"));
+    }
+
+    @Test
+    public void testGetTopicsByCategoryId_EmptyList() throws Exception {
+        Long categoryId = 1L;
+        Mockito.when(homeService.getTopicsByCategory(categoryId))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/categories/{categoryId}/topics", categoryId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    public void testGetTopicsByCategoryId_InvalidId() throws Exception {
+        Long categoryId = 999L;
+        Mockito.when(homeService.getTopicsByCategory(categoryId))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/categories/{categoryId}/topics", categoryId))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    public void testGetTopicsByCategoryId_MissingId() throws Exception {
+
+        mockMvc.perform(get("/categories/{categoryId}/topics", ""))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testGetTopicsByCategoryId_WrongTypeId() throws Exception {
+        String categoryId = "abc";
+
+        mockMvc.perform(get("/categories/{categoryId}/topics", categoryId))
+                .andExpect(status().isBadRequest());
+    }
+
+
+}

--- a/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
+++ b/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
@@ -94,8 +94,10 @@ public class HomeControllerTests {
                 .thenThrow(new CategoryNotFoundException("Category not found with id: " + categoryId));
 
         mockMvc.perform(get("/categories/{categoryId}/topics", categoryId))
-                .andExpect(status().isInternalServerError())
-                .andExpect(content().string(""));
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.statusCode").value(404))
+                .andExpect(jsonPath("$.message").value("Category not found with id: " + categoryId));
     }
 
     @Test

--- a/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
+++ b/src/test/java/com/javaProject/AptitudeApp/controller/HomeControllerTests.java
@@ -4,7 +4,7 @@ import com.javaProject.AptitudeApp.dto.CategoryDto;
 import com.javaProject.AptitudeApp.dto.TopicDto;
 import com.javaProject.AptitudeApp.exception.CategoryNotFoundException;
 import com.javaProject.AptitudeApp.exception.GlobalExceptionHandler;
-import com.javaProject.AptitudeApp.service.Impl.HomeService;
+import com.javaProject.AptitudeApp.service.IHomeService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +27,7 @@ public class HomeControllerTests {
     private MockMvc mockMvc;
 
     @MockitoBean
-    private HomeService homeService;
+    private IHomeService homeService;
 
     @Test
     public void testGetAllCategories() throws Exception {


### PR DESCRIPTION
Closes #7 

This pull request introduces improved error handling for category-related endpoints, refactors some REST API routes for clarity and consistency, and adds comprehensive tests for the `HomeController`. The main focus is on providing more informative error responses and ensuring the API adheres to RESTful conventions.

**Error handling improvements:**

* Added a custom exception `CategoryNotFoundException` and a global exception handler (`GlobalExceptionHandler`) to return structured error responses with appropriate HTTP status codes when a category is not found. Also introduced an `ErrorResponse` class to standardize error messages.
* Updated `HomeService` to throw `CategoryNotFoundException` instead of a generic `RuntimeException` when a category is not found.

**REST API route improvements:**

* Changed the endpoint for fetching topics by category from `/topics/{categoryId}` to `/categories/{categoryId}/topics` in `HomeController` for better RESTful design.
* Updated `QuizController` routes to use `/topics/{slug}/quiz` instead of `/{slug}/quiz`, and changed the `@GetMapping` path accordingly. 

**Testing enhancements:**

* Added a new test class `HomeControllerTests` with tests for all category and topic endpoints, including cases for empty results, invalid IDs, missing IDs, and type mismatches, ensuring robust coverage of both success and error scenarios.